### PR TITLE
Update to service-implementation build.gradle

### DIFF
--- a/service-implementation/build.gradle
+++ b/service-implementation/build.gradle
@@ -80,9 +80,9 @@ dependencies {
     // for file upload
     // TODO - See that we also depend on "jersey-bundle" inherently
     // TODO - due to NetFlix... using the bundle is not advised... (remove)
-    compile 'com.sun.jersey:jersey-core:1.17'
-    compile 'com.sun.jersey:jersey-server:1.14'
-    compile 'com.sun.jersey:jersey-json:1.17'
+    compile 'com.sun.jersey:jersey-core:1.17.1'
+    compile 'com.sun.jersey:jersey-server:1.17.1'
+    compile 'com.sun.jersey:jersey-json:1.17.1'
     compile 'javax.mail:mail:1.4.6'
     compile 'com.sun.jersey.contribs:jersey-multipart:1.17.1'
 


### PR DESCRIPTION
Jersey multi-part functionality gives errors unless all Jersey jars are the same version.  Updated the service-implementation build.gradle file to make all Jersey jars 1.17.1 version.
